### PR TITLE
Removed the apostrophe in Add-On's to be Add-Ons

### DIFF
--- a/src/data/site-nav-structure.json
+++ b/src/data/site-nav-structure.json
@@ -79,7 +79,7 @@
     }
   },
   "add-ons": {
-    "title": "Add-On's",
+    "title": "Add-Ons",
     "subnav": {
       "overview": "Overview",
       "card": "Card",


### PR DESCRIPTION
I don't think there should be an apostrophe in Add-Ons.
