### PR TITLE
Removed colors from Tag page

### DIFF
--- a/src/content/components/tag/style.md
+++ b/src/content/components/tag/style.md
@@ -1,21 +1,3 @@
-## Color
-
-| Color                   | Tag Hex   | Text Hex |
-|-------------------------------------|----------|
-| IBM                     | #C0E6FF   | #325C80  |
-| Beta                    | #DFE6EB   | #394B54  |
-| Third-Party             | #A7FAE6   | #0D6C5D  |
-| Local/Dedicated/Custom  | #EED2FF   | #734098  |
-| Experimental            | #FFD791   | #872A0F  |
-| Community               | #C8F08F   | #2D660A  |
-| Private                 | #FDE876   | #735F00  |
-
----
-***
-> ![Tag color examples](images/tag-style-2.png)
-
-_Tag color examples_
-
 ## Typography
 
 Tag text should be set in sentence case, and should only have one word. However, if more than one is necessary, then connect the words using a hyphen with no spaces.


### PR DESCRIPTION
Tag colors were removed from the Style tab of the Tag component (since these aren't in our color palette and library). 