### PR TITLE
Fixed broken link in SP guidelines

### DIFF
--- a/src/content/getting-started/service-providers/general.md
+++ b/src/content/getting-started/service-providers/general.md
@@ -41,7 +41,7 @@ Your service UI (e.g. Configuration, Dashboard) should follow [WCAG AA](https://
 <!--* Does your design consider [color usage](http://carbondesignsystem.com/style/colors/usage) and pass the [color contrast ratio](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)? -->
 
 ### Service icon
-Review the [service icon guidelines](#) for information on the design, production, approval, and submission of service icons.
+Review the [service icon guidelines](/getting-started/service-providers/service-icon) for information on the design, production, approval, and submission of service icons.
 
 ### IBM Cloud UI
 #### IBM Cloud Platform


### PR DESCRIPTION
* Fixed broken link for SP guidelines (internal)

I noticed that the "do's and don'ts" aren't styled properly. The whole section and images under Icon guidelines should be styled like this. 

I'm okay to push this to deploy next week since we're limited on time. Just let me know what you think @marijohannessen !

## Current staging
<img width="381" alt="screen shot 2018-01-11 at 2 24 44 pm" src="https://user-images.githubusercontent.com/11233508/34845681-5c45f1a6-f6db-11e7-9e0f-9e29d34a6d85.png">

## Intended design
<img width="610" alt="screen shot 2018-01-11 at 2 24 52 pm" src="https://user-images.githubusercontent.com/11233508/34845683-5dba00a4-f6db-11e7-8844-310b47ceb0b8.png">
