### PR TITLE
fix(misc): ie11 fixes

### DIFF
--- a/src/app/pages/overview/Overview.js
+++ b/src/app/pages/overview/Overview.js
@@ -37,7 +37,7 @@ class Overview extends React.Component {
   moveLetters = (e) => {
     const icons = e.currentTarget.querySelectorAll('g');
     const a = this.interpolate(0, 35);
-    icons.forEach(icon => {
+    [...icons].forEach(icon => {
       const currentIcon = icon;
       const iconObj = icon.getBoundingClientRect();
 

--- a/src/polyfills/index.js
+++ b/src/polyfills/index.js
@@ -1,9 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import 'core-js/modules/es6.array.fill';
 import 'core-js/modules/es6.array.from';
+import 'core-js/modules/es7.array.includes';
 import 'core-js/modules/es6.math.sign';
 import 'core-js/modules/es6.object.assign';
+import 'core-js/modules/es7.object.values';
 import 'core-js/modules/es6.promise.js';
 import 'core-js/modules/es6.string.includes';
+import 'core-js/modules/es6.string.trim';
 /* eslint-enable import/no-extraneous-dependencies */
 
 import './custom-event';


### PR DESCRIPTION
Fixes #196.

This changes does the following:

* Add required polyfills for `carbon-components-react`
* Eliminate `NodeList.forEach()` call as it's not supported by IE11