### PR TITLE
Fixes to Utilities section

### DIFF
--- a/src/app/components/internal/MarkdownPage/markdown-page.scss
+++ b/src/app/components/internal/MarkdownPage/markdown-page.scss
@@ -120,13 +120,18 @@
   }
 
   p code,
-  li code {
+  li code,
+  td code {
     font-size: 0.875rem;
     padding: 0.25rem;
     background-color: $field-01;
     color: $text-02;
     font-family: 'ibm-plex-mono', Courier, monospace;
     -webkit-font-smoothing: auto;
+  }
+
+  td code {
+    line-height: 2;
   }
 
   pre {
@@ -139,6 +144,7 @@
       font-size: 0.875rem;
       word-break: break-all;
       line-height: 1.5;
+      color: $text-02;
     }
 
     & + h4 {

--- a/src/app/components/internal/Page/page-overwrites.scss
+++ b/src/app/components/internal/Page/page-overwrites.scss
@@ -54,8 +54,14 @@ main[data-page|='whats-new'] {
   }
 }
 
-main[data-page='style-spacing'] {
+main[data-page='style-spacing'],
+main[data-page='utilities-disabled-states'],
+main[data-page='utilities-filtering'] {
   img {
     background-color: $ui-02;
   }
+}
+
+img[src='/images/small-loading-1.gif'] {
+  border: 1px solid $ui-03;
 }

--- a/src/app/pages/utilities/Utilities.js
+++ b/src/app/pages/utilities/Utilities.js
@@ -11,11 +11,13 @@ class Utilities extends React.Component {
 
   render() {
     const { params } = this.props;
+    const title = params.name.charAt(0).toUpperCase() + params.name.substring(1).replace('-', ' ');
+
     const content = (
       <MarkdownPage content={require(`../../../content/utilities/${params.name}/${params.name}.md`)} />
     );
     return (
-      <Page label="Utilities" title="" content={content} />
+      <Page label="Utilities" title={title} content={content} />
     );
   }
 }

--- a/src/content/utilities/disabled-states/disabled-states.md
+++ b/src/content/utilities/disabled-states/disabled-states.md
@@ -1,5 +1,4 @@
-
-A disabled state is applied to a component when the user is not allowed to interact with the component due to either permissions, dependencies or pre-requisites. Disabled states completely remove the interactive function of a component.
+**_A disabled state_ is applied to a component when the user is not allowed to interact with the component due to either permissions, dependencies or pre-requisites. Disabled states completely remove the interactive function of a component.**
 
 ## Disabled variations
 

--- a/src/content/utilities/filtering/filtering.md
+++ b/src/content/utilities/filtering/filtering.md
@@ -1,4 +1,4 @@
-Filtering is the action by which a user adds or removes data items from a shown data set by turning on and off certain predefined criteria.
+**_Filtering_ is the action by which a user adds or removes data items from a shown data set by turning on and off certain predefined criteria.**
 
 ## Selecting filters
 
@@ -65,10 +65,16 @@ Filters within each category should start either as all unselected or all select
 ### Filter applied
 If the filter(s) can be hidden in either a drawer, dropdown, or menu, then there should be an indicator visible on the closed filter state that informs the user that filters have been applied. At a minimum the indicator should include the number of filters applied and have the option to clear filters without re-opening the filter container.
 
+---
+***
+> 
 ![Hidden filters not applied](images/filter-5.png)
 
 _Filters not applied_
 
+---
+***
+> 
 ![Hidden filters applied](images/filter-6.png)
 
 _Filters applied_

--- a/src/content/utilities/loading/loading.md
+++ b/src/content/utilities/loading/loading.md
@@ -1,4 +1,4 @@
-Loading is applied when additional information takes an extended amount of time to process and appear on screen. Skeleton states and the Loading component are two interactions that communicate to users that data is currently loading and the screen is not frozen.
+**_Loading_ is applied when additional information takes an extended amount of time to process and appear on screen. Skeleton states and the Loading component are two interactions that communicate to users that data is currently loading and the screen is not frozen.**
 
 
 ## Skeleton States

--- a/src/content/utilities/overflow-content/overflow-content.md
+++ b/src/content/utilities/overflow-content/overflow-content.md
@@ -1,4 +1,4 @@
-Overflow content is text, such as a paragraph or a text string, that exceeds a desired space. It also applies to a series of components that surpass a given space. Overflow content is typically reduced to fit a space or reduce repetition. Truncation and ‘Show more’ Buttons are two ways to indicate that overflow content is continued elsewhere or below the fold.
+**_Overflow content_ is text, such as a paragraph or a text string, that exceeds a desired space. It also applies to a series of components that surpass a given space. Overflow content is typically reduced to fit a space or reduce repetition. Truncation and ‘Show more’ Buttons are two ways to indicate that overflow content is continued elsewhere or below the fold.**
 
 
 ## Truncation
@@ -8,6 +8,9 @@ Truncation is typically used for static text or Links. Truncated items are repre
 
 _Example of a browser tooltip being used for truncation._
 
+---
+***
+> 
 ![Example of end-line truncation for a paragraph.](images/Truncated-Paragraph.png)
 
 _Example of end-line truncation for a paragraph._


### PR DESCRIPTION
- [x] The titles on the pages should reflect the selected section. Currently its just empty, could not figure out how to make it pull in the section name
- [x] Disabled states > all images need `ui-02` backgrounds
- [x] Loading > small loader image needs gray outline `ui-03`
- [x] First paragraph of each section should be bold and the component name at the beginning of the first sentence should be `brand-01`
- [x] Truncation > 2nd image (Truncated items always... paragraph image) > shrink image so it isn't stretched out
- [x] Truncation chart > can we put the number sin `1234` inline code? I couldn't get it to work in the markdown chart
- [x] Filtering > all images need the `ui-02` backgrounds
- [x] Filtering > images 5 and 6 need to be shrunk down 