### PR TITLE
chore(LiveComponent): refer to dist version of HTML

### DIFF
--- a/src/app/components/internal/CodePage/CodePage.js
+++ b/src/app/components/internal/CodePage/CodePage.js
@@ -99,36 +99,36 @@ class CodePage extends Component {
     let htmlFile;
     if (parent === 'dropdown') {
       if (variation === 'dropdown') {
-        htmlFile = require('carbon-components/src/components/dropdown/dropdown.html');
+        htmlFile = require('carbon-components/html/dropdown/dropdown.html');
       } else {
         return this.renderReactComponent(parent, variation, title);
       }
     } else {
       if (parent === 'text-input' && variation === 'text-area') {
-        htmlFile = require('carbon-components/src/components/text-area/text-area.html');
+        htmlFile = require('carbon-components/html/text-area/text-area.html');
       } else if (parent === 'data-table' && variation === 'toolbar') {
-        htmlFile = require('carbon-components/src/components/toolbar/toolbar.html');
+        htmlFile = require('carbon-components/html/toolbar/toolbar.html');
       } else if (parent === 'date-picker' && variation === 'time-picker') {
-        htmlFile = require('carbon-components/src/components/time-picker/time-picker.html');
+        htmlFile = require('carbon-components/html/time-picker/time-picker.html');
       } else if (parent === 'data-table' && variation === 'data-table-v2') {
-        htmlFile = require('carbon-components/src/components/data-table-v2/data-table-v2.html');
+        htmlFile = require('carbon-components/html/data-table-v2/data-table-v2.html');
       } else if (
         parent === 'data-table' &&
         variation === 'data-table-v2-expandable'
       ) {
-        htmlFile = require('carbon-components/src/components/data-table-v2/data-table-v2-expandable.html');
+        htmlFile = require('carbon-components/html/data-table-v2/data-table-v2-expandable.html');
       } else if (
         parent === 'data-table' &&
         variation === 'data-table-v2--pagination'
       ) {
-        htmlFile = require('carbon-components/src/components/data-table-v2/data-table-v2--pagination.html');
+        htmlFile = require('carbon-components/html/data-table-v2/data-table-v2--pagination.html');
       } else if (
         parent === 'data-table' &&
         variation === 'data-table-v2--small'
       ) {
-        htmlFile = require('carbon-components/src/components/data-table-v2/data-table-v2--small.html');
+        htmlFile = require('carbon-components/html/data-table-v2/data-table-v2--small.html');
       } else {
-        htmlFile = require(`carbon-components/src/components/${parent}/${variation}.html`);
+        htmlFile = require(`carbon-components/html/${parent}/${variation}.html`);
       }
       if (parent === 'card') {
         const oldPath = '/globals/assets/images/placeholder-icon-32x32.svg';
@@ -209,9 +209,9 @@ class CodePage extends Component {
     } else {
       let htmlFile;
       if (component === 'cloud-header') {
-        htmlFile = require('carbon-addons-bluemix/src/components/cloud-header/cloud-header.html');
+        htmlFile = require('carbon-addons-bluemix/html/cloud-header/cloud-header.html');
       } else {
-        htmlFile = require(`carbon-components/src/components/${component}/${component}.html`); // eslint-disable-line
+        htmlFile = require(`carbon-components/html/${component}/${component}.html`); // eslint-disable-line
       }
       componentContent = (
         <ComponentExample

--- a/src/app/components/internal/LiveComponent/LiveComponent.js
+++ b/src/app/components/internal/LiveComponent/LiveComponent.js
@@ -51,43 +51,43 @@ class LiveComponent extends Component {
     });
     let htmlFile;
     if (this.props.component === 'text-input' && variation === 'text-area') {
-      htmlFile = require('carbon-components/src/components/text-area/text-area.html');
+      htmlFile = require('carbon-components/html/text-area/text-area.html');
     } else if (
       this.props.component === 'data-table' &&
       variation === 'toolbar'
     ) {
-      htmlFile = require('carbon-components/src/components/toolbar/toolbar.html');
+      htmlFile = require('carbon-components/html/toolbar/toolbar.html');
     } else if (
       this.props.component === 'detail-page-header--no-tabs' ||
       this.props.component === 'detail-page-header--with-tabs'
     ) {
-      htmlFile = require(`carbon-components/src/components/detail-page-header/${
+      htmlFile = require(`carbon-components/html/detail-page-header/${
         this.props.component
       }.html`);
     } else if (
       this.props.component === 'data-table' &&
       variation === 'data-table-v2'
     ) {
-      htmlFile = require('carbon-components/src/components/data-table-v2/data-table-v2.html');
+      htmlFile = require('carbon-components/html/data-table-v2/data-table-v2.html');
     } else if (
       this.props.component === 'data-table' &&
       variation === 'data-table-v2-expandable'
     ) {
-      htmlFile = require('carbon-components/src/components/data-table-v2/data-table-v2-expandable.html');
+      htmlFile = require('carbon-components/html/data-table-v2/data-table-v2-expandable.html');
     } else if (
       this.props.component === 'data-table' &&
       variation === 'data-table-v2--pagination'
     ) {
-      htmlFile = require('carbon-components/src/components/data-table-v2/data-table-v2--pagination.html');
+      htmlFile = require('carbon-components/html/data-table-v2/data-table-v2--pagination.html');
     } else if (
       this.props.component === 'data-table' &&
       variation === 'data-table-v2--small'
     ) {
-      htmlFile = require('carbon-components/src/components/data-table-v2/data-table-v2--small.html');
+      htmlFile = require('carbon-components/html/data-table-v2/data-table-v2--small.html');
     } else if (this.props.component === 'header') {
-      htmlFile = require('carbon-addons-bluemix/src/components/cloud-header/cloud-header.html');
+      htmlFile = require('carbon-addons-bluemix/html/cloud-header/cloud-header.html');
     } else {
-      htmlFile = require(`carbon-components/src/components/${
+      htmlFile = require(`carbon-components/html/${
         this.props.component
       }/${variation}.html`);
     }


### PR DESCRIPTION
This PR changes the HTML file references from ones in `node_modules/carbon-components/src` to ones in `node_modules/carbon-components/html`. This change allows us to put a build step in `carbon-components` repo for HTML files being used in carbondesignsystem.com site - A way to generate HTML files from Handlebars, etc. template, discussed in: https://github.com/carbon-design-system/carbon-components/pull/579