### PR TITLE
Fix JS error navigating to sub-expando with keyboard

### DIFF
--- a/src/app/components/internal/SideNav/SideNav.js
+++ b/src/app/components/internal/SideNav/SideNav.js
@@ -135,78 +135,88 @@ class SideNav extends Component {
       const isCurrentPath = currentPath[1] === navItem;
       return (
         <SideNavItem key={navItem} isActiveItem={isCurrentPath}>
-          <Link
-            aria-label={navItemObj.title}
-            tabIndex="0"
-            className="main-nav-item__heading"
-            to={`/${navItem}`}
-          >
-            {navItemObj.title}
-          </Link>
+          {
+            ({ open: isItemOpen }) => (
+              <Link
+                aria-label={navItemObj.title}
+                tabIndex={this.props.isOpen && isItemOpen ? 0 : -1}
+                className="main-nav-item__heading"
+                to={`/${navItem}`}
+              >
+                {navItemObj.title}
+              </Link>
+            )
+          }
         </SideNavItem>
       );
     });
 
   renderSubNav = (subnav, parentItem) => {
-    const subNavItems = this.renderSubNavItems(subnav, parentItem);
     const currentPath = browserHistory.getCurrentLocation().pathname.split("/");
     const isCurrentPath = currentPath[1] === parentItem;
     return (
       <SideNavItem key={parentItem} isCurrentPath={isCurrentPath}>
-        <p className="main-nav-item__heading">
-          {SiteNavStructure[parentItem].title}
-          <Icon
-            className="main-nav-item__arrow"
-            name="caret--down"
-            aria-hidden="true"
-            description="Menu arrow icon"
-            alt="Menu arrow icon"
-          />
-        </p>
-        <ul
-          role="menu"
-          aria-label={`${SiteNavStructure[parentItem].title} sub menu`}
-          aria-hidden="true"
-          className="main-nav__sub-nav"
-        >
-          {subNavItems}
-        </ul>
+        {
+          ({ open: isItemOpen }) => [(
+            <p className="main-nav-item__heading">
+              {SiteNavStructure[parentItem].title}
+              <Icon
+                className="main-nav-item__arrow"
+                name="caret--down"
+                aria-hidden="true"
+                description="Menu arrow icon"
+                alt="Menu arrow icon"
+              />
+            </p>
+          ), (
+            <ul
+              role="menu"
+              aria-label={`${SiteNavStructure[parentItem].title} sub menu`}
+              aria-hidden="true"
+              className="main-nav__sub-nav"
+            >
+              {this.renderSubNavItems(subnav, parentItem, isItemOpen)}
+            </ul>
+          )]
+        }
       </SideNavItem>
     );
   };
 
-  renderInnerSubNav = (parent, parentKey) => {
-    const innerSubNavItems = this.renderInnerSubNavItems(
-      parent.subnav,
-      parentKey
-    );
+  renderInnerSubNav = (parent, parentKey, isOpen) => {
+    const { subnav } = parent;
     const currentPath = browserHistory.getCurrentLocation().pathname.split("/");
     const isCurrentPath = currentPath[1] === parentKey;
     return (
       <SideNavItem type="sub" key={parentKey} isCurrentPath={isCurrentPath}>
-        <p className="sub-nav__item">
-          {parent.title}
-          <Icon
-            className="sub-nav-item__arrow"
-            name="caret--down"
-            aria-hidden="true"
-            description="Menu arrow icon"
-            alt="Menu arrow icon"
-          />
-        </p>
-        <ul
-          role="menu"
-          aria-label={`${parent.title} sub menu`}
-          aria-hidden="true"
-          className="sub-nav__inner-sub-nav"
-        >
-          {innerSubNavItems}
-        </ul>
+        {
+          ({ open: isItemOpen, onKeyDown }) => [(
+            <p className="sub-nav__item" onKeyDown={onKeyDown} tabIndex={isOpen ? 0 : undefined}>
+              {parent.title}
+              <Icon
+                className="sub-nav-item__arrow"
+                name="caret--down"
+                aria-hidden="true"
+                description="Menu arrow icon"
+                alt="Menu arrow icon"
+              />
+            </p>
+          ), (
+            <ul
+              role="menu"
+              aria-label={`${parent.title} sub menu`}
+              aria-hidden="true"
+              className="sub-nav__inner-sub-nav"
+            >
+              {this.renderInnerSubNavItems(subnav, parentKey, isItemOpen)}
+            </ul>
+          )]
+        }
       </SideNavItem>
     );
   };
 
-  renderInnerSubNavItems = (subnav, parentItem) => {
+  renderInnerSubNavItems = (subnav, parentItem, isItemOpen) => {
     const currentPath = browserHistory.getCurrentLocation().pathname.split("/");
     const { ENV } = process.env;
     return Object.keys(subnav).map(subNavItem => {
@@ -228,7 +238,7 @@ class SideNav extends Component {
       if (isServiceProviders || isUserFlow) {
         return "";
       }
-      const tabIndex = this.props.isOpen ? 0 : -1;
+      const tabIndex = this.props.isOpen && isItemOpen ? 0 : -1;
       return (
         <li
           role="menuitem"
@@ -249,12 +259,12 @@ class SideNav extends Component {
     });
   };
 
-  renderSubNavItems = (subnav, parentItem) => {
+  renderSubNavItems = (subnav, parentItem, isItemOpen) => {
     const currentPath = browserHistory.getCurrentLocation().pathname.split("/");
     const { ENV } = process.env;
     return Object.keys(subnav).map(subNavItem => {
       if (typeof subnav[subNavItem] === "object") {
-        return this.renderInnerSubNav(subnav[subNavItem], subNavItem);
+        return this.renderInnerSubNav(subnav[subNavItem], subNavItem, isItemOpen);
       } else {
         const link = `/${parentItem}/${subNavItem}`;
         const isCurrentPage =
@@ -269,7 +279,7 @@ class SideNav extends Component {
         if (isServiceProviders || isUserFlow) {
           return "";
         }
-        const tabIndex = this.props.isOpen ? 0 : -1;
+        const tabIndex = this.props.isOpen && isItemOpen ? 0 : -1;
         return (
           <li
             role="menuitem"

--- a/src/app/components/internal/SideNav/_sub-nav.scss
+++ b/src/app/components/internal/SideNav/_sub-nav.scss
@@ -36,6 +36,7 @@
 
     &:focus {
       outline: 0;
+      font-weight: 600;
     }
 
     &:first-child {

--- a/src/app/components/internal/SideNavItem/SideNavItem.js
+++ b/src/app/components/internal/SideNavItem/SideNavItem.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 class SideNavItem extends Component {
   static propTypes = {
     className: PropTypes.string,
-    children: PropTypes.node,
+    children: PropTypes.func,
     isCurrentPath: PropTypes.bool,
     isActiveItem: PropTypes.bool,
     type: PropTypes.string
@@ -46,57 +46,51 @@ class SideNavItem extends Component {
   };
 
   handleKeyDown = evt => {
-    if (evt.which === 13) {
-      const targetIsSubItem = evt.target.classList.contains('sub-nav__item') || evt.target.classList.contains('sub-nav__item-link');
-      const hasSubMenu = !(evt.currentTarget.querySelector('ul') === null);
-      if (!targetIsSubItem && hasSubMenu) {
-        const open = !this.state.open;
-        this.setState({ open });
-        const subMenu = evt.currentTarget.querySelector('ul');
-        if (!this.state.open) {
-          let height = 0;
-          [...subMenu.children].forEach(child => {
-            height += child.offsetHeight;
-          });
-          subMenu.style.maxHeight = `${height}px`;
-        } else {
-          const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
-          if (!evt.currentTarget.classList.contains('main-nav-item__open') && isIE11) {
-            subMenu.style.maxHeight = 0;
-          } else if (!isIE11) {
-            subMenu.style.maxHeight = 0;
-          }
+    if (evt.which === 13 && evt.target === evt.currentTarget) { // Does not handle bubbled up events
+      const open = !this.state.open;
+      this.setState({ open });
+      const subMenu = this.elem.querySelector('ul');
+      if (!this.state.open) {
+        let height = 0;
+        [...subMenu.children].forEach(child => {
+          height += child.offsetHeight;
+        });
+        subMenu.style.maxHeight = `${height}px`;
+      } else {
+        const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+        if (!this.elem.classList.contains('main-nav-item__open') && isIE11) {
+          subMenu.style.maxHeight = 0;
+        } else if (!isIE11) {
+          subMenu.style.maxHeight = 0;
         }
       }
     }
     if (evt.which === 39) {
       document.querySelector('#maincontent').focus();
     }
-    [...evt.currentTarget.querySelectorAll('.sub-nav__item')].forEach(link => {
-      const currentLink = link;
-      if (this.state.open) {
-        currentLink.querySelector('a').tabIndex = 0;
-      } else {
-        currentLink.querySelector('a').tabIndex = -1;
-      }
-    });
+  };
+
+  handleRef = elem => {
+    this.elem = elem;
   };
 
   render() {
+    const isSub = this.props.type === 'sub';
     const { children, isActiveItem } = this.props;
+    const { open } = this.state;
 
     const classNames = classnames({
       'main-nav-item': true,
-      'main-nav-item__open': this.state.open,
+      'main-nav-item__open': open,
       'main-nav-item__active': isActiveItem,
-      'main-nav-item--sub': this.props.type === 'sub'
+      'main-nav-item--sub': isSub,
     });
 
-    const tabIndex = children.length ? 0 : -1;
+    const tabIndex = children.length && !isSub ? 0 : undefined;
 
     return (
-      <li role="menuitem" tabIndex={tabIndex} className={classNames} onClick={this.handleClick} onKeyDown={this.handleKeyDown}>
-        {children}
+      <li role="menuitem" tabIndex={tabIndex} className={classNames} onClick={this.handleClick} onKeyDown={this.handleKeyDown} ref={this.handleRef}>
+        {children({ open, onKeyDown: this.handleKeyDown })}
       </li>
     );
   }


### PR DESCRIPTION
By letting React handle `tabIndex` property instead of doing so via DOM.

Also:

* Fixes the focus style of sub-expando
* Supports opening/closing sub-expando with keyboard
* Addresses: #208

Review will be easier by clicking on “Diff settings” and checking off "Hide whitespace changes”.