### PR TITLE
Skip link doesn't work #263

### DIFF
--- a/src/app/components/internal/SideNav/SideNav.js
+++ b/src/app/components/internal/SideNav/SideNav.js
@@ -294,7 +294,7 @@ class SideNav extends Component {
     return (
       <nav role="navigation" aria-label="Page Navigation" aria-expanded={isOpen} className={classNames}>
         <div className="side-nav__top-container">
-          <a id="skip-to-content" tabIndex="0" role="button" className="skip-to-content" onKeyDown={this.handleSkip}>
+          <a id="skip-to-content" href="#maincontent" className="skip-to-content" onKeyDown={this.handleSkip}>
             Skip to main content
           </a>
           <Link to="/" className="side-nav__logo">


### PR DESCRIPTION
- Fixes skip link by adding `href="#maincontent"`
- also removed `role="button"` because a skip link is a "link"
(note: don't need explicit `role="link"` because the default role for anchor elements is "link")
- also removed `tabindex="0"` because an anchor with an href is in the tab order by default
