### PR TITLE
'a' elements do not support 'alt' #267

### DIFF
--- a/src/app/components/internal/PageFooter/PageFooter.js
+++ b/src/app/components/internal/PageFooter/PageFooter.js
@@ -105,14 +105,15 @@ class PageFooter extends Component {
     return (
       <footer className={footerClasses}>
         <div className="page-footer__content">
-          <p className="page-footer__text page-footer__version-link">
+          <p className="page-footer__text page-footer__version-link" id="page-footer__version-label">
             Component version{' '}
             <a
               className="page-footer__link"
               href="https://github.com/carbon-design-system/carbon-components/releases"
               rel="noopener"
               target="_blank"
-              alt="Carbon Components GitHub repo"
+              aria-labelledby="page-footer__version-label page-footer__version-number"
+              id="page-footer__version-number"
             >
               {version}
             </a>
@@ -130,7 +131,7 @@ class PageFooter extends Component {
                 className="social-media__link"
                 rel="noopener"
                 target="_blank"
-                alt="Dribble account for Carbon"
+                aria-label="Dribble account for Carbon"
               >
                 {dribbble}
               </a>
@@ -141,7 +142,7 @@ class PageFooter extends Component {
                 className="social-media__link"
                 rel="noopener"
                 target="_blank"
-                alt="Medium account for Carbon"
+                aria-label="Medium account for Carbon"
               >
                 {medium}
               </a>
@@ -152,7 +153,7 @@ class PageFooter extends Component {
                 className="social-media__link"
                 rel="noopener"
                 target="_blank"
-                alt="Twitter account for Carbon"
+                aria-label="Twitter account for Carbon"
               >
                 {twitter}
               </a>
@@ -163,7 +164,7 @@ class PageFooter extends Component {
                 className="social-media__link"
                 rel="noopener"
                 target="_blank"
-                alt="GitHub account for Carbon"
+                aria-label="GitHub account for Carbon"
               >
                 {github}
               </a>
@@ -182,7 +183,7 @@ class PageFooter extends Component {
               className="page-footer__link"
               rel="noopener"
               target="_blank"
-              alt="Open a GitHub issue"
+              aria-label="Open a GitHub issue"
             >
               issue
             </a>{' '}


### PR DESCRIPTION
- Uses `aria-label` instead of `alt` on anchor links in the footer

- One of the links (the component version link) had alt text that was quite different from the visual text. This type of thing is a problem for speech recognition systems users, who would expect to say, for example:
> "Click 9.0.0 link"

to activate the link, but since aria-label and aria-labelledby override the link's label, and since the original alt text was "Carbon Components GitHub repo", the voice command would not know which link to click.
To fix this particular link, I decided to use a 2-part label (the aria-labelledby points to 2 ids) to concatenate the string "Component version" with the version string (9.0.0) which gives: "Component version 9.0.0". So the voice command:
> "Click 9.0.0 link"

will actually find the link labelled "Component version 9.0.0" because "9.0.0" is part of the label.
As an added bonus, the 2-part label is better for screen reader users listening to the link's label to try to figure out what the link does.