### PR TITLE
Add new getting started for other frameworks page

### DIFF
--- a/src/app/pages/getting-started/Developers.js
+++ b/src/app/pages/getting-started/Developers.js
@@ -11,7 +11,7 @@ class Developers extends React.Component {
   };
 
   render() {
-    const tabs = ['vanilla', 'react'];
+    const tabs = ['vanilla', 'react','other'];
     let currentPage = tabs[0];
     if (this.props.currentPage) {
       currentPage = this.props.currentPage;
@@ -24,6 +24,9 @@ class Developers extends React.Component {
         </Tab>
         <Tab href="/getting-started/developers/react" label="React">
           <MarkdownPage content={require('../../../content/getting-started/developers/react.md')} />
+        </Tab>
+        <Tab href="/getting-started/developers/other" label="Other">
+          <MarkdownPage content={require('../../../content/getting-started/developers/other.md')} />
         </Tab>
       </PageTabs>
     );

--- a/src/content/getting-started/developers/other.md
+++ b/src/content/getting-started/developers/other.md
@@ -1,0 +1,36 @@
+**The Carbon team currently only officially supports vanilla js and React. However developers using a different javascript framework (such as Angular or Vue) can can follow the instructions for the [Vanilla](/getting-started/developers/vanilla) library to access the styles and build out their own components.**
+
+## Development
+
+**Wrapping a component with a JavaScript framework of your choice**
+
+Many JavaScript frameworks have a mechanism to dynamically create/destroy DOM elements, for example, upon change in array.
+This often makes it unclear when the DOM element to instantiate Carbon component on is available, which often depends on the JavaScript framework you use.
+
+Also when DOM elements that Carbon components have been instantiated on are being destroyed, the Carbon component instances should be released so that e.g. there are no zombie event handlers.
+
+The easiest way to hook on the creation/destroy of DOM elements is defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
+
+```javascript
+class BXLoading extends HTMLElement {
+  // Called when this custom element gets into render tree
+  connectedCallback() {
+    // "this" here is "<bx-loading>" element
+    this.innerHTML = '(e.g. snippet from http://carbondesignsystem.com/components/loading/code)';
+    this.loading = CarbonComponents.Loading.create(this.querySelector('[data-loading]'));
+  }
+  // Called when this custom element gets out of render tree
+  disconnectedCallback() {
+    this.loading.release();
+  }
+}
+customElements.define('bx-loading', BXLoading);
+```
+
+## Examples
+
+[Angular 4 wrapper for Carbon](https://codepen.io/asudoh/pen/VryJBO?editors=1010)
+
+## Troubleshooting
+
+If you experience any issues while getting set up with Carbon Components, please head over to the [GitHub repo](https://github.com/carbon-design-system/carbon-components) for more guidelines and support. Please [create an issue](https://github.com/carbon-design-system/carbon-components/issues) if your issue does not already exist.

--- a/src/content/getting-started/developers/other.md
+++ b/src/content/getting-started/developers/other.md
@@ -5,11 +5,11 @@
 **Wrapping a component with a JavaScript framework of your choice**
 
 Many JavaScript frameworks have a mechanism to dynamically create/destroy DOM elements, for example, upon change in array.
-This often makes it unclear when the DOM element to instantiate Carbon component on is available, which often depends on the JavaScript framework you use.
+This often makes it unclear when the DOM element to instantiate a Carbon component is available, which often depends on the JavaScript framework you use.
 
 Also when DOM elements that Carbon components have been instantiated on are being destroyed, the Carbon component instances should be released so that e.g. there are no zombie event handlers.
 
-The easiest way to hook on the creation/destroy of DOM elements is defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
+The easiest way to hook on the creation/destroy of DOM elements is by defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
 
 ```javascript
 class BXLoading extends HTMLElement {
@@ -33,4 +33,4 @@ customElements.define('bx-loading', BXLoading);
 
 ## Troubleshooting
 
-If you experience any issues while getting set up with Carbon Components, please head over to the [GitHub repo](https://github.com/carbon-design-system/carbon-components) for more guidelines and support. Please [create an issue](https://github.com/carbon-design-system/carbon-components/issues) if your issue does not already exist.
+If you experience any issues while getting set up with Carbon Components, please head over to the [Carbon Components GitHub repo](https://github.com/carbon-design-system/carbon-components) for more guidelines and support. Please [create an issue](https://github.com/carbon-design-system/carbon-components/issues) if your issue does not already exist.

--- a/src/content/getting-started/developers/other.md
+++ b/src/content/getting-started/developers/other.md
@@ -9,7 +9,7 @@ This often makes it unclear when the DOM element to instantiate a Carbon compone
 
 Also when DOM elements that Carbon components have been instantiated on are being destroyed, the Carbon component instances should be released so that e.g. there are no zombie event handlers.
 
-The easiest way to hook on the creation/destroy of DOM elements is by defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
+The easiest way to hook on the creation/destruction of DOM elements is by defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
 
 ```javascript
 class BXLoading extends HTMLElement {

--- a/src/content/getting-started/developers/vanilla.md
+++ b/src/content/getting-started/developers/vanilla.md
@@ -206,11 +206,11 @@ follow the instructions in [the next section](#wrapping-a-component-with-javascr
 #### Wrapping a component with JavaScript framework of your choice
 
 Many JavaScript frameworks have a mechanism to dynamically create/destroy DOM elements, for example, upon change in array.
-This often makes it unclear when the DOM element to instantiate Carbon component on is available, which often depends on the JavaScript framework you use.
+This often makes it unclear when the DOM element to instantiate a Carbon component is available, which often depends on the JavaScript framework you use.
 
 Also when DOM elements that Carbon components have been instantiated on are being destroyed, the Carbon component instances should be released so that e.g. there are no zombie event handlers.
 
-The easiest way to hook on the creation/destroy of DOM elements is defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
+The easiest way to hook on the creation/destroy of DOM elements is by defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
 
 ```javascript
 class BXLoading extends HTMLElement {

--- a/src/content/getting-started/developers/vanilla.md
+++ b/src/content/getting-started/developers/vanilla.md
@@ -210,7 +210,7 @@ This often makes it unclear when the DOM element to instantiate a Carbon compone
 
 Also when DOM elements that Carbon components have been instantiated on are being destroyed, the Carbon component instances should be released so that e.g. there are no zombie event handlers.
 
-The easiest way to hook on the creation/destroy of DOM elements is by defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
+The easiest way to hook on the creation/destruction of DOM elements is by defining a "wrapping component", with the JavaScript framework of your choice. Here's an example using Web Components' [Custom Elements v1 spec](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements), but the notion of components, along with the lifecycle callbacks, are commonly found in many other JavaScript frameworks.
 
 ```javascript
 class BXLoading extends HTMLElement {


### PR DESCRIPTION
https://github.ibm.com/carbon/issues/issues/804

Adds a new Getting Started tab for developers using a framework other than vanilla/react. 

Wasn't sure if we wanted to link out to any of the unofficial angular or vue frameworks, although I think they are internal anyway? 