### PR TITLE
Define floating menu target

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -140,7 +140,7 @@ class App extends Component {
       currentLocation === 'live' ? '' : <SideNavToggle onToggleBtnClick={this.onToggleBtnClick} isOpen={this.state.isOpen} />;
 
     return (
-      <div className="wrapper" onLoad={this.initCustomComponents}>
+      <div data-floating-menu-container className="wrapper" onLoad={this.initCustomComponents}>
         {toggleBtnContent}
         {sideNavContent}
         <div className={classNames}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import window from 'window-or-global';
-import React from 'react';
+import React, { Fragment } from 'react';
 import ReactDOM from 'react-dom';
 import { Router, browserHistory } from 'react-router';
 import routes from './routes';
@@ -26,6 +26,9 @@ window.addEventListener('load', () => {
 });
 
 ReactDOM.render(
-  <Router history={browserHistory} onUpdate={logPageView} routes={routes} />,
+  <Fragment>
+    <Router history={browserHistory} onUpdate={logPageView} routes={routes} />
+    <input type="text" className="bx--visually-hidden" />
+  </Fragment>,
   document.getElementById('root'),
 );


### PR DESCRIPTION
This change adds an attribute to the top-level node in `<App>`, indicating that floating menus should be put there. Also puts a hidden `<input>` next to `<App>` to trap keyboard focus.

Fixes carbon-design-system/carbon-components#910.